### PR TITLE
[MNOE-113] Display backend flash messages

### DIFF
--- a/src/app/index.run.coffee
+++ b/src/app/index.run.coffee
@@ -44,3 +44,12 @@ angular.module 'mnoEnterpriseAngular'
 
     $translate.use(locale)
   )
+
+   # Display flash messages from the backend in toastr
+   # They're passed this way:
+   #    ?flash={"msg":"An error message.","type":"error"}
+  .run (toastr, $location) ->
+    if flash = $location.search().flash
+      message = JSON.parse(flash)
+      toastr[message.type](message.msg, _.capitalize(message.type), timeout: 10000)
+      $location.search('flash', null) # remove the flash from url


### PR DESCRIPTION
Display flash messages from the backend in a toastr.
They're passed this way:
    `?flash={"msg":"An error message.","type":"error"}`