### PR TITLE
Config backward compatible with the mnoe backend

### DIFF
--- a/src/app/index.default-config.coffee
+++ b/src/app/index.default-config.coffee
@@ -1,0 +1,12 @@
+# For backward compatibility with the mnoe backend
+# Define null/default values for all the constants so that if the backend hasn't been upgraded
+# to define this constants you don't get errors like:
+#   Uncaught Error: [$injector:unpr] Unknown provider: INTERCOM_IDProvider <- INTERCOM_ID <- AnalyticsSvc
+angular.module('mnoEnterprise.defaultConfiguration', [])
+  .constant('IMPAC_CONFIG', {})
+  .constant('I18N_CONFIG', {})
+  .constant('PRICING_CONFIG', {enabled: true})
+  .constant('DOCK_CONFIG', {enabled: true})
+  .constant('GOOGLE_TAG_CONTAINER_ID', null)
+  .constant('APP_NAME', null)
+  .constant('INTERCOM_ID', null)

--- a/src/app/index.module.coffee
+++ b/src/app/index.module.coffee
@@ -1,4 +1,6 @@
 angular.module 'mnoEnterpriseAngular', [
+  # Default configuration
+  'mnoEnterprise.defaultConfiguration',
   # Runtime configuration
   'mnoEnterprise.configuration',
 


### PR DESCRIPTION
Avoid Unknown provider error when the frontend is newer than the
backend and using constants that are not defined in the backend config
file.