### PR TITLE
Change color variable text loader to match loader color

### DIFF
--- a/src/app/views/layout.less
+++ b/src/app/views/layout.less
@@ -18,7 +18,7 @@
   .layout-loading-text {
     display: inline-block;
     padding-top: 15px;
-    color: @bg-inverse-color;
+    color: @dashboard-loader-color;
   }
 }
 


### PR DESCRIPTION
@alexnoox 
@x4d3 

The variables gif loader and text loader are pointing at different places, one points at theme.less and the other point at variables.less, therefore when I change the colour of the loader, the text remains with the same colour, it looks VERY ugly and I need to be overwrite the text. This way both will point at the same variable.less, saving time and bugs.

I hope this is ok.

Thanks.