### PR TITLE
Fix impac dashboard double loading

### DIFF
--- a/src/app/components/dashboard-menu/dashboard-menu.controller.coffee
+++ b/src/app/components/dashboard-menu/dashboard-menu.controller.coffee
@@ -14,10 +14,11 @@ angular.module 'mnoEnterpriseAngular'
         $scope.$watch(MnoeOrganizations.getSelected, (newValue, oldValue) ->
           if newValue?
             # Impac! is displayed only to admin and super admin
-            $scope.isAdmin = (MnoeOrganizations.role.isAdmin() || MnoeOrganizations.role.isSuperAdmin())
+            $scope.isAdmin = MnoeOrganizations.role.isAtLeastAdmin()
             $scope.isDockEnabled = DOCK_CONFIG.enabled
             $scope.isLoading = false
-            $state.go('home.login') if oldValue? && newValue != oldValue
+
+            $state.go('home.apps') unless $scope.isAdmin
         )
 
         return

--- a/src/app/views/impac/impac.controller.coffee
+++ b/src/app/views/impac/impac.controller.coffee
@@ -15,10 +15,9 @@ angular.module 'mnoEnterpriseAngular'
       MnoeOrganizations.get().then(
         ->
           # Impac is displayed only to admin and super admin
-          vm.isImpacShown = (MnoeOrganizations.role.isAdmin() || MnoeOrganizations.role.isSuperAdmin())
+          vm.isImpacShown = MnoeOrganizations.role.atLeastAdmin()
+          $state.go('home.login') unless vm.isImpacShown
 
-          if !vm.isImpacShown
-            $state.go('home.login')
       ) if newValue?
     )
 

--- a/src/app/views/login-router/login-router.coffee
+++ b/src/app/views/login-router/login-router.coffee
@@ -4,7 +4,7 @@ angular.module 'mnoEnterpriseAngular'
     $scope.$watch(MnoeOrganizations.getSelected, (newValue) ->
       if newValue?
         # Impac! is displayed only to admin and super admin
-        if (MnoeOrganizations.role.isAdmin() || MnoeOrganizations.role.isSuperAdmin())
+        if MnoeOrganizations.role.atLeastAdmin()
           $state.go('home.impac')
         else
           $state.go('home.apps')


### PR DESCRIPTION
Prevent unnecessary $state redirect to #/login to authenticate
user role by using MnoeOrganizations.role methods directly in the
dashboardMenu directive controller.

@alexnoox please review