### PR TITLE
Revert "Develop angular 1.6.0"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -50,7 +50,7 @@
   "resolutions": {
     "angular-bootstrap": "~0.14.3",
     "angular-messages": "^1.5.3",
-    "angular": "1.6.0",
+    "angular": "1.5.9",
     "moment": "^2.11.2"
   }
 }


### PR DESCRIPTION
Reverts maestrano/mno-enterprise-angular#102

Angular 1.6 is a major version that needs a round of testing. Also the impac! team will need to make sure they are not using anything deprecated in this version.

FYI @xaun @cesar-tonnoir 