### PR TITLE
Fix angular token error

### DIFF
--- a/src/app/index.run.coffee
+++ b/src/app/index.run.coffee
@@ -44,8 +44,8 @@ angular.module 'mnoEnterpriseAngular'
         <div ng-switch on="allowHtml">
           <div ng-switch-default ng-if="title" class="{{titleClass}}" aria-label="{{title | translate}}">{{title | translate:extraData}}</div>
           <div ng-switch-default class="{{messageClass}}" aria-label="{{message | translate:extraData}}">{{message | translate:extraData}}</div>
-          <div ng-switch-when="true" ng-if="title" class="{{titleClass}}" ng-bind-html="{{title | translate:extraData}}"></div>
-          <div ng-switch-when="true" class="{{messageClass}}" ng-bind-html="{{message | translate:extraData}}"></div>
+          <div ng-switch-when="true" ng-if="title" class="{{titleClass}}" ng-bind-html="title | translate:extraData"></div>
+          <div ng-switch-when="true" class="{{messageClass}}" ng-bind-html="message | translate:extraData"></div>
         </div>
         <progress-bar ng-if="progressBar"></progress-bar>
       </div>


### PR DESCRIPTION
@alexnoox I noticed a token error in the console anytime there is an in-app alert. This was due to the ng-bind-html directive having braces => {} around it. 