### PR TITLE
uib-carousel & uib-slide cannot be an element

### DIFF
--- a/src/app/views/marketplace/marketplace-app.html
+++ b/src/app/views/marketplace/marketplace-app.html
@@ -25,11 +25,11 @@
         <div class="row">
           <div class="col-md-8">
             <div class="well carousel">
-              <uib-carousel interval="3000">
-                <uib-slide ng-repeat="picture in vm.app.pictures" class="screenshot">
+              <div uib-carousel interval="3000">
+                <div uib-slide ng-repeat="picture in vm.app.pictures" class="screenshot">
                   <img ng-src={{picture}} alt="screenshot">
-                </uib-slide>
-              </uib-carousel>
+                </div>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
Regardless what the documentation says (https://angular-ui.github.io/bootstrap/#/carousel)
```
Use a <uib-carousel> element with <uib-slide> elements inside it.
```
 the code specifically restrict uib-carousel & uib-slide to be an attribute (https://github.com/angular-ui/bootstrap/blob/master/src/carousel/carousel.js#L289).

@ouranos FYI