### PR TITLE
Temporarily disable angular-translate logger

### DIFF
--- a/src/app/index.config.coffee
+++ b/src/app/index.config.coffee
@@ -56,5 +56,7 @@ angular.module 'mnoEnterpriseAngular'
 
     $translateProvider.fallbackLanguage(LOCALES.fallbackLanguage)
     $translateProvider.useSanitizeValueStrategy('sanitizeParameters')
-    $translateProvider.useMissingTranslationHandlerLog()
+
+    # TODO: Activate in "developer mode" only (spams the console and makes the application lag)
+    # $translateProvider.useMissingTranslationHandlerLog()
   )


### PR DESCRIPTION
The logging of missing translations in production spams the console and makes the application lag => temporarily disabling it until a "developer mode" is available in mnoe-angular.

-- Tested on my local