### PR TITLE
[MNOE-437] Fix wrong default tab in organization

### DIFF
--- a/src/app/views/company/company.controller.coffee
+++ b/src/app/views/company/company.controller.coffee
@@ -7,12 +7,6 @@ angular.module 'mnoEnterpriseAngular'
       # Pre-Initialization
       #====================================
       vm.isLoading = true
-      vm.tabs = {
-        billing: false,
-        members: false,
-        teams: false,
-        settings: false
-      }
       vm.payment_enabled = not PAYMENT_CONFIG.disabled
 
       #====================================
@@ -21,9 +15,9 @@ angular.module 'mnoEnterpriseAngular'
       vm.initialize = ->
         vm.isLoading = false
         if vm.isBillingShown()
-          vm.tabs.billing = true
+          vm.activeTab = 'billing'
         else
-          vm.tabs.members = true
+          vm.activeTab = 'members'
 
       vm.isTabSetShown = ->
         !vm.isLoading && (

--- a/src/app/views/company/company.html
+++ b/src/app/views/company/company.html
@@ -29,12 +29,12 @@
   <!-------------------------------------->
   <div class="col-md-12 top-buffer-4" ng-if="vm.isTabSetShown() && !vm.isLoading">
 
-    <div uib-tabset>
+    <div uib-tabset active="vm.activeTab">
 
       <!-------------------------------------->
       <!--         Billing Section          -->
       <!-------------------------------------->
-      <div uib-tab ng-if="vm.isBillingShown()" active="vm.tabs.billing">
+      <div uib-tab index="'billing'" ng-if="vm.isBillingShown()" >
         <div uib-tab-heading>{{ 'mno_enterprise.templates.dashboard.organization.index.billing.title' | translate }}</div>
 
         <!-- Directive: DashboardOrganizationArrears -->
@@ -90,7 +90,7 @@
       <!-------------------------------------->
       <!--        Members Section           -->
       <!-------------------------------------->
-      <div uib-tab active="vm.tabs.members">
+      <div uib-tab index="'members'">
         <div uib-tab-heading>{{ 'mno_enterprise.templates.dashboard.organization.index.members.title' | translate }}</div>
 
         <!-- Directive: DashboardOrganizationMembers -->
@@ -106,7 +106,7 @@
       <!-------------------------------------->
       <!--     Team Management Section      -->
       <!-------------------------------------->
-      <div uib-tab active="tabs.teams">
+      <div uib-tab index="'team'">
         <div uib-tab-heading>{{ 'mno_enterprise.templates.dashboard.organization.index.teams.title' | translate }}</div>
 
         <div class="clearfix">
@@ -127,7 +127,7 @@
       <!-------------------------------------->
       <!--        Audit Log Section         -->
       <!-------------------------------------->
-      <div uib-tab active="vm.tabs.audit_log" ng-if="vm.isAuditLogShown()">
+      <div uib-tab index="'audit'" ng-if="vm.isAuditLogShown()">
         <div uib-tab-heading>{{ 'mno_enterprise.templates.dashboard.organization.index.audit_log.title' | translate }}</div>
 
         <!-- Directive: DashboardOrganizationAuditLog -->
@@ -143,7 +143,7 @@
       <!-------------------------------------->
       <!--    Company Settings Section      -->
       <!-------------------------------------->
-      <div uib-tab ng-show="vm.isSettingsShown()" active="vm.tabs.settings">
+      <div uib-tab index="'settings'" ng-show="vm.isSettingsShown()" >
         <div uib-tab-heading>{{ 'mno_enterprise.templates.dashboard.organization.index.settings.title' | translate }}</div>
 
         <div class="well clearfix">


### PR DESCRIPTION
@ouranos 

The "active" is a setting for uib-tabset, but not in the uib-tab, so I got rid of it.
The ng-if does not work properly together with uib-tab, as a result all the idexes where messed up.
I added new indexes on each tab as strings for readibility.
I use the index to set the default tab depending of the condition vm.isBillingShown.
