### PR TITLE
[MNOE-407] Fix error when onboarding is disabled

### DIFF
--- a/src/app/index.route.coffee
+++ b/src/app/index.route.coffee
@@ -114,7 +114,9 @@ angular.module 'mnoEnterpriseAngular'
             controllerAs: 'vm'
 
     $urlRouterProvider.otherwise ($injector, $location) ->
-      $state.go('home.impac') unless ONBOARDING_WIZARD_CONFIG.enabled
+      unless ONBOARDING_WIZARD_CONFIG.enabled
+        $location.url('/impac')
+        return
 
       MnoeOrganizations = $injector.get('MnoeOrganizations')
       MnoeAppInstances = $injector.get('MnoeAppInstances')


### PR DESCRIPTION
@ouranos Please review

If the onboarding is disabled, the page cannot load due to a missing dependency. This PR fix this error.