### PR TITLE
Add gulp task to ensure locales in development

### DIFF
--- a/gulp/locales.js
+++ b/gulp/locales.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var gulp   = require('gulp');
+var $ = require('gulp-load-plugins')();
+
+gulp.task('locales', function () {
+  gulp.src('bower_components/impac-angular/dist/locales/*')
+  .pipe($.rename(function (filename) {
+    filename.basename = filename.basename.slice(0, 2);
+  }))
+  .pipe(gulp.dest('src/locales/impac'))
+});

--- a/gulp/server.js
+++ b/gulp/server.js
@@ -7,15 +7,13 @@ var conf = require('./conf');
 var browserSync = require('browser-sync');
 var browserSyncSpa = require('browser-sync-spa');
 
-var util = require('util');
-
 var proxyMiddleware = require('http-proxy-middleware');
 
 function browserSyncInit(baseDir, browser) {
   browser = browser === undefined ? 'default' : browser;
 
   var routes = null;
-  if(baseDir === conf.paths.src || (util.isArray(baseDir) && baseDir.indexOf(conf.paths.src) !== -1)) {
+  if(baseDir === conf.paths.src || (Array.isArray(baseDir) && baseDir.indexOf(conf.paths.src) !== -1)) {
     routes = {
       '/bower_components': 'bower_components'
     };
@@ -59,7 +57,7 @@ browserSync.use(browserSyncSpa({
   selector: '[ng-app]'// Only needed for angular apps
 }));
 
-gulp.task('serve', ['watch'], function () {
+gulp.task('serve', ['watch', 'locales'], function () {
   browserSyncInit([path.join(conf.paths.tmp, '/serve'), conf.paths.src]);
 });
 

--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -11,7 +11,6 @@ var $ = require('gulp-load-plugins')();
 
 var wiredep = require('wiredep').stream;
 var _ = require('lodash');
-var rename = require("gulp-rename");
 
 
 // generate sprites
@@ -55,7 +54,7 @@ gulp.task('less-concat', function() {
     .pipe(wiredep(_.extend({}, conf.wiredep)))
     .pipe($.replace('../../../bower_components/', '../bower_components/'))
     .pipe($.replace('../../bower_components/', '../bower_components/'))
-    .pipe(rename({ basename: "theme-previewer" }))
+    .pipe($.rename({ basename: "theme-previewer" }))
     .pipe(gulp.dest(path.join(conf.paths.dist, '/styles/')))
 });
 


### PR DESCRIPTION
- Remove deprecated `util.isArray()`

@ouranos @cesar-tonnoir @xaun 
Tiny gulp task that runs before `gulp serve` to ensure locales are available in development 