### PR TITLE
[MNOE-541] Fix build when variable-default not present

### DIFF
--- a/gulp_tasks/styles.js
+++ b/gulp_tasks/styles.js
@@ -30,8 +30,7 @@ function styles() {
   var injectFiles = gulp.src([
     conf.path.src('/app/stylesheets/theme.less'),
     conf.path.src('/app/stylesheets/*.less'),
-    conf.path.src('/app/stylesheets/variables-default.less'),
-    conf.path.src('/app/stylesheets/variables.less'),
+    conf.path.src('/app/stylesheets/variables*.less'),
     conf.path.src('/app/**/*.less'),
     conf.path.src('/fonts/**/*.less'),
     conf.path.src('/images/**/*.less'),


### PR DESCRIPTION
Using a `variables*` will preserve the order and still work when `variables-default.less` is not present (ie: when building from the project folder)

Test:
```js
var glob = require("glob")

glob("src/app/stylesheets/variables*.less", {}, function (er, files) {
  console.log(files)
})
```

```
∫ node test.js 
[ 'src/app/stylesheets/variables-default.less',
  'src/app/stylesheets/variables.less' ]
```