### PR TITLE
Fix star ratings bug

### DIFF
--- a/src/app/views/marketplace/marketplace-app.controller.coffee
+++ b/src/app/views/marketplace/marketplace-app.controller.coffee
@@ -398,7 +398,6 @@ angular.module 'mnoEnterpriseAngular'
       updateAverageRating = (rating) ->
         # Update average rating
         vm.averageRating = if rating? then parseFloat(rating).toFixed(1) else -1
-        # vm.isRateDisplayed = !!vm.averageRating
         vm.isRateDisplayed = vm.averageRating >= 0
 
       #====================================

--- a/src/app/views/marketplace/marketplace-app.controller.coffee
+++ b/src/app/views/marketplace/marketplace-app.controller.coffee
@@ -397,8 +397,9 @@ angular.module 'mnoEnterpriseAngular'
 
       updateAverageRating = (rating) ->
         # Update average rating
-        vm.averageRating = if rating? then parseFloat(rating).toFixed(1) else null
-        vm.isRateDisplayed = !!vm.averageRating
+        vm.averageRating = if rating? then parseFloat(rating).toFixed(1) else -1
+        # vm.isRateDisplayed = !!vm.averageRating
+        vm.isRateDisplayed = vm.averageRating >= 0
 
       #====================================
       # Post-Initialization


### PR DESCRIPTION
@alexnoox This is regarding a bug where, when the first review is added to an app, the star rating towards the top of the page does not update unless the page is refreshed. I think this has something to do with averageRating being set to Null. I think for some reason it is messing with the average-star-rating component and it is not able to update properly (maybe related to the $watch function in average-star-rating) as this only happens when there are no reviews, and also happens if you delete all the reviews and add one again (all without refreshing). 