### PR TITLE
Reset promise when app ratings are updated (Rating stars bug fix)

### DIFF
--- a/src/app/components/mnoe-api/marketplace.svc.coffee
+++ b/src/app/components/mnoe-api/marketplace.svc.coffee
@@ -35,7 +35,7 @@ angular.module 'mnoEnterpriseAngular'
         (response) ->
           app_review = response.data.plain()
           app_review
-      )
+      ).finally(-> marketplacePromise = null)
 
     @editReview = (appId, feedback_id, feedback) ->
       payload = feedback
@@ -50,7 +50,7 @@ angular.module 'mnoEnterpriseAngular'
         (response) ->
           app_review = response.data.plain()
           app_review
-      )
+      ).finally(-> marketplacePromise = null)
 
     @addAppReviewComment = (appId, data) ->
       payload = {app_comment: data}


### PR DESCRIPTION
@alexnoox @ouranos The ratings still had a bug when clicking the back button and then opening the same app as the rating would not be updated in the marketplacePromise. Should be all good now. 👍  Please review. 