### PR TITLE
Handle $ref in product JSON schemas

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
     "ng-page-title": "^1.1.1",
     "restangular": "~1.5.1",
     "material-shadows": "^3.0.1",
-    "angular-schema-form": "^0.8.13",
+    "angular-schema-form": "^1.0.0-alpha.4",
     "angular-schema-form-bootstrap": "^0.2.0",
     "angular-filter": "^0.5.16",
     "mno-ui-elements": "maestrano/mno-ui-elements#master"

--- a/src/app/views/provisioning/details.controller.coffee
+++ b/src/app/views/provisioning/details.controller.coffee
@@ -1,5 +1,5 @@
 angular.module 'mnoEnterpriseAngular'
-  .controller('ProvisioningDetailsCtrl', ($state, MnoeProvisioning) ->
+  .controller('ProvisioningDetailsCtrl', ($state, MnoeProvisioning, schemaForm) ->
 
     vm = this
 
@@ -9,10 +9,17 @@ angular.module 'mnoEnterpriseAngular'
     vm.isEditMode = !_.isEmpty(vm.subscription.custom_data)
 
     # The schema is contained in field vm.product.custom_schema
-    MnoeProvisioning.findProduct(id: vm.subscription.product.id).then(
-      (response) ->
-        vm.schema = JSON.parse(response.custom_schema)
-    )
+    #
+    # jsonref is used to resolve $ref references
+    # jsonref is not cyclic at this stage hence the need to make a
+    # reasonable number of passes (2 below + 1 in the sf-schema directive)
+    # to resolve cyclic references
+    #
+    MnoeProvisioning.findProduct(id: vm.subscription.product.id)
+      .then((response) -> JSON.parse(response.custom_schema))
+      .then((schema) -> schemaForm.jsonref(schema))
+      .then((schema) -> schemaForm.jsonref(schema))
+      .then((schema) -> vm.schema = schema)
 
     vm.submit = (form) ->
       return if form.$invalid


### PR DESCRIPTION
Summary of changes:
- Upgrade angular-schema-form to 1.0.0-alpha4
- Force multiples passes on JSON schemas to resolve $ref pointers