### PR TITLE
[MNOE-621][BUG] Update angular moment with fallback locale

### DIFF
--- a/src/app/components/mno-locale-config/mno-locale-config.svc.coffee
+++ b/src/app/components/mno-locale-config/mno-locale-config.svc.coffee
@@ -63,6 +63,7 @@ angular.module 'mnoEnterpriseAngular'
       if (angular.isString(LOCALES.fallbackLanguage) && LOCALES.fallbackLanguage not in fallbackStack)
         fallbackStack.push(LOCALES.fallbackLanguage)
 
+      amMoment.changeLocale(fallbackStack[0])
       $translate.fallbackLanguage(fallbackStack)
 
     return @


### PR DESCRIPTION
@alexnoox When no locale is set via the url or user, `setFallbackStack` is called. Since the function doesn't set a locale for angular Moment.js, the date on the subscription page is appearing in chinese. This should take care of the issue. Please review. :)