### PR TITLE
Update isInteger for IE11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,8 @@
     "angular-schema-form-datepicker": "~1.4.1",
     "angular-filter": "^0.5.16",
     "mno-ui-elements": "maestrano/mno-ui-elements#master",
-    "textAngular": "^1.5.16"
+    "textAngular": "^1.5.16",
+    "es6-shim": "^0.35.3"
   },
   "devDependencies": {
     "angular-mocks": "~1.6.0"

--- a/src/app/index.controller.coffee
+++ b/src/app/index.controller.coffee
@@ -1,6 +1,10 @@
 angular.module 'mnoEnterpriseAngular'
-  .controller 'IndexController', ($scope, $sce, GOOGLE_TAG_CONTAINER_ID, INTERCOM_ID) ->
+  .controller 'IndexController', ($scope, $sce, GOOGLE_TAG_CONTAINER_ID, INTERCOM_ID, $window) ->
     'ngInject'
+
+    # Patches isInteger function for IE11 as ES6 is not yet supported
+    $window.Number.isInteger = Number.isInteger || (value) ->
+      typeof value == "number" && isFinite(value) && Math.floor(value) == value
 
     $scope.google_tag_scripts = $sce.trustAsHtml("""
         <noscript>

--- a/src/app/index.controller.coffee
+++ b/src/app/index.controller.coffee
@@ -2,10 +2,6 @@ angular.module 'mnoEnterpriseAngular'
   .controller 'IndexController', ($scope, $sce, GOOGLE_TAG_CONTAINER_ID, INTERCOM_ID, $window) ->
     'ngInject'
 
-    # Patches isInteger function for IE11 as ES6 is not yet supported
-    $window.Number.isInteger = Number.isInteger || (value) ->
-      typeof value == "number" && isFinite(value) && Math.floor(value) == value
-
     $scope.google_tag_scripts = $sce.trustAsHtml("""
         <noscript>
             <iframe src=\"\/\/www.googletagmanager.com/ns.html?id=#{GOOGLE_TAG_CONTAINER_ID}\" height=\"0\" width=\"0\" style=\"display:none;visibility:hidden\"></iframe>

--- a/src/app/index.controller.coffee
+++ b/src/app/index.controller.coffee
@@ -1,5 +1,5 @@
 angular.module 'mnoEnterpriseAngular'
-  .controller 'IndexController', ($scope, $sce, GOOGLE_TAG_CONTAINER_ID, INTERCOM_ID, $window) ->
+  .controller 'IndexController', ($scope, $sce, GOOGLE_TAG_CONTAINER_ID, INTERCOM_ID) ->
     'ngInject'
 
     $scope.google_tag_scripts = $sce.trustAsHtml("""


### PR DESCRIPTION
@alexnoox This PR should take care of some issues on the change password page. The function comes from ES6 which is not supported by IE11 so this replaces the function in that case. Please review. 