### PR TITLE
[MNOE-718] Theme Previewer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,8 @@
     "mno-ui-elements": "maestrano/mno-ui-elements#master",
     "textAngular": "^1.5.16",
     "json-formatter": "^0.6.0",
-    "es6-shim": "^0.35.3"
+    "es6-shim": "^0.35.3",
+    "angular-spectrum-colorpicker": "^1.4.5"
   },
   "devDependencies": {
     "angular-mocks": "~1.6.0"

--- a/src/app/components/theme-editor/theme-editor.html
+++ b/src/app/components/theme-editor/theme-editor.html
@@ -23,7 +23,7 @@
             <div class="form-group col-md-6" ng-repeat="(color, value) in theme">
               <label>{{labels[color]}} <br/><small class="text-muted">{{color}}</small></label>
               <spectrum-colorpicker
-                ng-model="theme[color]" ng-model-options="{ debounce: 300 }" ng-change="editor.update()" palette
+                ng-model="theme[color]" ng-model-options="{ debounce: 300 }" ng-change="editor.update()"
                 options="{showInput: true, showAlpha: true, showPalette: true, showSelectionPalette: true, format: 'hex'}">
               </spectrum-colorpicker>
             </div>

--- a/src/app/components/theme-editor/theme-editor.html
+++ b/src/app/components/theme-editor/theme-editor.html
@@ -17,16 +17,15 @@
         </div>
         <div ng-show="editor.busy"><i class="fa fa-spinner fa-pulse fa-2x"></i></div>
       </div>
-
       <uib-tabset class="top-buffer-2">
         <uib-tab heading="Theme">
           <div class="row top-buffer-1">
             <div class="form-group col-md-6" ng-repeat="(color, value) in theme">
               <label>{{labels[color]}} <br/><small class="text-muted">{{color}}</small></label>
-              <input type="color" class="form-control"
-                     ng-model="theme[color]"
-                     ng-model-options="{ debounce: 300 }"
-                     ng-change="editor.update()">
+              <spectrum-colorpicker
+                ng-model="theme[color]" ng-model-options="{ debounce: 300 }" ng-change="editor.update()" palette
+                options="{showInput: true, showAlpha: true, showPalette: true, showSelectionPalette: true, format: 'hex'}">
+              </spectrum-colorpicker>
             </div>
           </div>
         </uib-tab>

--- a/src/app/components/theme-editor/theme-editor.less
+++ b/src/app/components/theme-editor/theme-editor.less
@@ -38,4 +38,26 @@ theme-editor {
       display: inline-block;
     }
   }
+
+  .sp-replacer {
+    width: 100%;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+  }
+
+  .sp-preview {
+    margin: 2px;
+    width: ~"calc(100% - 18px)";
+    border-radius: 4px;
+    border-color: #ccc;
+    z-index:150;
+  }
+
+  .sp-preview-inner {
+    border-radius: 4px;
+  }
+
+  .sp-dd {
+    margin: 2px 2px 2px;
+  }
 }

--- a/src/app/components/theme-editor/theme-editor.less
+++ b/src/app/components/theme-editor/theme-editor.less
@@ -15,7 +15,7 @@ theme-editor {
 
     &.closed {
       //right: 25px;
-      transform: translate3d(~'calc(100% - 30px)', 0, 0);
+      transform: translate3d(95%, 0, 0);
     }
 
     .collapse-switch-btn {

--- a/src/app/index.module.coffee
+++ b/src/app/index.module.coffee
@@ -22,5 +22,6 @@ angular.module 'mnoEnterpriseAngular', [
   'schemaForm',
   'angular.filter',
   'textAngular',
-  'jsonFormatter'
+  'jsonFormatter',
+  'angularSpectrumColorpicker'
 ]


### PR DESCRIPTION
https://maestrano.atlassian.net/browse/MNOE-718

IE11 Bug fixes for theme-previewer:

IE11 does not support the color input type.  I have implemented a color picker that is compatible across browsers.

IE11 does not allow the use of css calculations with 3d transform, which was preventing the theme previewer panel from closing. I have changed the value from (100%-30px) to be 95%, leaving 5% of the panel visible. 