### PR TITLE
[MNOE-750] Display SubscriptionEvent provisioning data

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "angular-filter": "^0.5.16",
     "mno-ui-elements": "maestrano/mno-ui-elements#master",
     "textAngular": "^1.5.16",
-    "json-formatter": "^0.6.0",
+    "angular-user-friendly-json-tree": "^2.0.1",
     "es6-shim": "^0.35.3",
     "angular-spectrum-colorpicker": "^1.4.5"
   },

--- a/src/app/index.config.coffee
+++ b/src/app/index.config.coffee
@@ -36,11 +36,6 @@ angular.module 'mnoEnterpriseAngular'
           $q.reject rejection
       }
 
-  .config((JSONFormatterConfigProvider) ->
-    # Enable the hover preview feature
-    JSONFormatterConfigProvider.hoverPreviewEnabled = true
-  )
-
   .config(($sceDelegateProvider) ->
     'ngInject'
 

--- a/src/app/index.module.coffee
+++ b/src/app/index.module.coffee
@@ -22,6 +22,6 @@ angular.module 'mnoEnterpriseAngular', [
   'schemaForm',
   'angular.filter',
   'textAngular',
-  'jsonFormatter',
+  'user-friendly-angular-json-tree',
   'angularSpectrumColorpicker'
 ]

--- a/src/app/views/provisioning/subscription.controller.coffee
+++ b/src/app/views/provisioning/subscription.controller.coffee
@@ -1,5 +1,5 @@
 angular.module 'mnoEnterpriseAngular'
-  .controller('ProvisioningSubscriptionCtrl', ($stateParams, MnoeProvisioning, MnoeMarketplace) ->
+  .controller('ProvisioningSubscriptionCtrl', ($stateParams, $filter, MnoeProvisioning, MnoeMarketplace) ->
 
     vm = this
     vm.isLoading = true
@@ -19,6 +19,12 @@ angular.module 'mnoEnterpriseAngular'
       (response) ->
         vm.subscriptionEvents = response.subscription_events
     )
+
+    # Configure user friendly json tree
+    vm.rootName = $filter('translate')('mno_enterprise.templates.dashboard.provisioning.subscription.events.provisioning_data.root_name')
+    vm.jsonTreeSettings = {
+      dateFormat: 'yyyy-MM-dd HH:mm:ss'
+    }
 
     return
   )

--- a/src/app/views/provisioning/subscription.html
+++ b/src/app/views/provisioning/subscription.html
@@ -65,12 +65,19 @@
 
         <div class="well subscription-events">
           <h3 class="text-color" translate>mno_enterprise.templates.dashboard.provisioning.subscription.events</h3>
-          <div ng-repeat="subscriptionEvent in vm.subscriptionEvents" class="row">
-            <div class="col-sm-2">{{ subscriptionEvent.created_at | amDateFormat: 'L' }}</div>
-            <div class="col-sm-1">{{ subscriptionEvent.event_type }}</div>
-            <div class="col-sm-1">{{ subscriptionEvent.status }}</div>
-            <div class="col-sm-4">{{ subscriptionEvent.message }}</div>
-            <div class="col-sm-4">{{ subscriptionEvent.provisioning_data }}</div>
+          <div ng-repeat="subscriptionEvent in vm.subscriptionEvents">
+            <div class="row subscription-event">
+              <div class="col-sm-2">{{ subscriptionEvent.created_at | amDateFormat: 'L' }}</div>
+              <div class="col-sm-2">{{ subscriptionEvent.event_type }}</div>
+              <div class="col-sm-2">{{ subscriptionEvent.status }}</div>
+              <div class="col-sm-6">{{ subscriptionEvent.message }}</div>
+            </div>
+
+            <div class="row subscription-event-provisioning-data" ng-if="subscriptionEvent.provisioning_data">
+              <div class="col-sm-10 col-sm-offset-2">
+                <user-friendly-json-tree start-expanded="false" object="subscriptionEvent.provisioning_data" options="vm.jsonTreeSettings" root-name="vm.rootName"></user-friendly-json-tree>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/views/provisioning/subscription.less
+++ b/src/app/views/provisioning/subscription.less
@@ -50,4 +50,13 @@
       padding-top: 6px;
     }
   }
+
+  .subscription-events .subscription-event {
+    padding-top: 5px;
+  }
+
+  .subscription-events .subscription-event-provisioning-data {
+    padding-bottom: 5px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.075);
+  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -701,6 +701,7 @@
   "mno_enterprise.templates.dashboard.provisioning.subscription.custom_data": "Information provided by the customer",
   "mno_enterprise.templates.dashboard.provisioning.subscription.no_custom_data": "No information provided by the customer",
   "mno_enterprise.templates.dashboard.provisioning.subscription.events": "Provisioning events",
+  "mno_enterprise.templates.dashboard.provisioning.subscription.events.provisioning_data.root_name": "Provisioning Data",
   "mno_enterprise.templates.dashboard.provisioning.subscriptions.title": "Manage your subscriptions",
   "mno_enterprise.templates.dashboard.provisioning.subscriptions.currency_warning": "Some prices are missing for your current currency. Please contact your administrator for more information.",
   "mno_enterprise.templates.dashboard.provisioning.subscriptions.name": "Name",


### PR DESCRIPTION
Feature preview:
![screenshot from 2017-11-02 11-28-22](https://user-images.githubusercontent.com/1684030/32304168-6178488c-bfc1-11e7-8894-9293c85d5402.png)

@alexnoox could you confirm that removing `json-formatter` and its configuration has no side effects? I haven't found pages where it was used previously.