### PR TITLE
[MNOE-780] - Use organization billing_currency

### DIFF
--- a/src/app/views/marketplace/marketplace-product.controller.coffee
+++ b/src/app/views/marketplace/marketplace-product.controller.coffee
@@ -20,7 +20,7 @@ angular.module 'mnoEnterpriseAngular'
           products = response.localProducts
           organization = response.organization
 
-          vm.orgCurrency = organization.billing?.current?.options?.iso_code || MnoeConfig.marketplaceCurrency()
+          vm.orgCurrency = organization.organization?.billing_currency || MnoeConfig.marketplaceCurrency()
 
           # App to be displayed
           productId = $stateParams.productId

--- a/src/app/views/provisioning/confirm.controller.coffee
+++ b/src/app/views/provisioning/confirm.controller.coffee
@@ -16,7 +16,7 @@ angular.module 'mnoEnterpriseAngular'
 
     MnoeOrganizations.get().then(
       (response) ->
-        vm.orgCurrency = response.billing?.current?.options?.iso_code || MnoeConfig.marketplaceCurrency()
+        vm.orgCurrency = response.organization?.billing_currency || MnoeConfig.marketplaceCurrency()
     )
 
     return

--- a/src/app/views/provisioning/order.controller.coffee
+++ b/src/app/views/provisioning/order.controller.coffee
@@ -11,7 +11,7 @@ angular.module 'mnoEnterpriseAngular'
 
     $q.all({organization: orgPromise, products: prodsPromise, subscription: initPromise}).then(
       (response) ->
-        vm.orgCurrency = response.organization.billing?.current?.options?.iso_code || MnoeConfig.marketplaceCurrency()
+        vm.orgCurrency = response.organization.organization?.billing_currency || MnoeConfig.marketplaceCurrency()
         vm.subscription = response.subscription
 
         MnoeMarketplace.findProduct({id: vm.subscription.product?.id, nid: $stateParams.nid}).then(

--- a/src/app/views/provisioning/subscriptions.controller.coffee
+++ b/src/app/views/provisioning/subscriptions.controller.coffee
@@ -28,7 +28,7 @@ angular.module 'mnoEnterpriseAngular'
 
     $q.all({organization: orgPromise, subscriptions: subPromise}).then(
       (response) ->
-        vm.orgCurrency = response.organization.billing?.current?.options?.iso_code || MnoeConfig.marketplaceCurrency()
+        vm.orgCurrency = response.organization.organization?.billing_currency || MnoeConfig.marketplaceCurrency()
 
         # If a subscription doesn't contains a pricing for the org currency, a warning message is displayed
         vm.displayCurrencyWarning = not _.every(response.subscriptions, (subscription) ->

--- a/src/app/views/provisioning/summary.controller.coffee
+++ b/src/app/views/provisioning/summary.controller.coffee
@@ -7,7 +7,7 @@ angular.module 'mnoEnterpriseAngular'
 
     MnoeOrganizations.get().then(
       (response) ->
-        vm.orgCurrency = response.billing?.current?.options?.iso_code || MnoeConfig.marketplaceCurrency()
+        vm.orgCurrency = response.organization?.billing_currency || MnoeConfig.marketplaceCurrency()
     )
 
     return


### PR DESCRIPTION
Point on new field organization.billing_currency rather than on the billing section, which is not available for all users (only super admins)

Depends on mnoe PR:
https://github.com/maestrano/mno-enterprise/pull/569
