### PR TITLE
[MNOE-794] [BUG] Insufficient Privileges Tooltip not showing on IE11

### DIFF
--- a/src/app/components/mno-app-install-btn/mno-app-install-btn.html
+++ b/src/app/components/mno-app-install-btn/mno-app-install-btn.html
@@ -4,16 +4,16 @@
     {{ 'mno_enterprise.templates.components.app_install_btn.conflicting_app' | translate }}
     <a ui-sref="home.marketplace.app({appId: $ctrl.conflictingApp.id})" ng-disabled="!$ctrl.canProvisionApp">{{$ctrl.conflictingApp.name}}</a>
   </div>
-  <a href="" ng-switch-when="INSTALLABLE" ng-click="!$ctrl.canProvisionApp || $ctrl.provisionApp()" ng-disabled="$ctrl.isLoadingButton || !$ctrl.canProvisionApp" class="btn btn-warning btn-promo btn-lg"
+  <a ng-switch-when="INSTALLABLE" ng-click="!$ctrl.canProvisionApp || $ctrl.provisionApp()" ng-class="{disabled: $ctrl.isLoadingButton || !$ctrl.canProvisionApp}" class="btn btn-warning btn-promo btn-lg"
     uib-tooltip="{{$ctrl.canProvisionApp? '' : 'mno_enterprise.templates.components.app_install_btn.insufficient_privilege' | translate}}">
     <span ng-show="$ctrl.isLoadingButton"><i class="fa fa-spinner fa-pulse"></i></span>
     {{ 'mno_enterprise.templates.components.app_install_btn.start_app' | translate }}
   </a>
-  <a href="" ng-switch-when="INSTALLED_LAUNCH" ng-click="!$ctrl.canProvisionApp || $ctrl.launchAppInstance()" ng-disabled="!$ctrl.canProvisionApp" class="btn btn-warning btn-promo btn-lg"
+  <a ng-switch-when="INSTALLED_LAUNCH" ng-click="!$ctrl.canProvisionApp || $ctrl.launchAppInstance()" ng-class="{disabled: !$ctrl.canProvisionApp}" class="btn btn-warning btn-promo btn-lg"
      uib-tooltip="{{$ctrl.canProvisionApp? '' : 'mno_enterprise.templates.components.app_install_btn.insufficient_privilege' | translate}}">
     {{ 'mno_enterprise.templates.components.app_install_btn.launch_app' | translate }}
   </a>
-  <a href="" ng-switch-when="INSTALLED_CONNECT" ng-click="!$ctrl.canProvisionApp || $ctrl.connectAppInstance()" ng-disabled="!$ctrl.canProvisionApp" class="btn btn-warning btn-promo btn-lg"
+  <a ng-switch-when="INSTALLED_CONNECT" ng-click="!$ctrl.canProvisionApp || $ctrl.connectAppInstance()" ng-class="{disabled: !$ctrl.canProvisionApp}" class="btn btn-warning btn-promo btn-lg"
      uib-tooltip="{{$ctrl.canProvisionApp? '' : 'mno_enterprise.templates.components.app_install_btn.insufficient_privilege' | translate}}">
     {{ 'mno_enterprise.templates.components.app_install_btn.connect_app' | translate }}
   </a>

--- a/src/app/components/mno-app-install-btn/mno-app-install-btn.less
+++ b/src/app/components/mno-app-install-btn/mno-app-install-btn.less
@@ -1,0 +1,3 @@
+a.disabled.btn, fieldset[disabled] a.btn {
+  pointer-events: auto;
+}


### PR DESCRIPTION
@alexnoox @ouranos The tooltip works properly in ie11 now. On internet explorer, when using the ng-disabled directive, the browser prevents all tooltips from showing. 