### PR TITLE
Impac! permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [Unreleased](https://github.com/maestrano/mno-enterprise-angular/tree/master)
+
+**Dependencies:**
+
+Requires MnoHub containing [maestrano/maestrano-hub#818](https://github.com/maestrano/maestrano-hub/pull/818) (eg: v2.0.0-rc8+)
+Requires Mno Enterprise containing [maestrano/mno-enterprise#588](https://github.com/maestrano/mno-enterprise/pull/588) (v3.4)
+
 ## [v1.1.3](https://github.com/maestrano/mno-enterprise-angular/tree/v1.1.3) (2017-11-10)
 [Full Changelog](https://github.com/maestrano/mno-enterprise-angular/compare/v1.1.2...v1.1.3)
 

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "animate.css": "~3.5.2",
     "bootstrap": "~3.3.5",
     "font-awesome": "~4.7.0",
-    "impac-angular": "~1.6.0",
+    "impac-angular": "~1.7.0",
     "jquery": "~3.1.0",
     "less": "~2.5.3",
     "lodash": "~3.10.1",

--- a/src/app/components/dashboard-menu/dashboard-menu.controller.coffee
+++ b/src/app/components/dashboard-menu/dashboard-menu.controller.coffee
@@ -8,17 +8,16 @@ angular.module 'mnoEnterpriseAngular'
       restrict: 'EA'
       templateUrl: 'app/components/dashboard-menu/dashboard-menu.html',
 
-      controller: ($scope, MnoeCurrentUser, MnoeOrganizations, DOCK_CONFIG, ORGANIZATION_MANAGEMENT, MARKETPLACE_CONFIG) ->
-        $scope.isDockEnabled = DOCK_CONFIG.enabled
+      controller: ($scope, MnoeOrganizations, ImpacConfigSvc, DOCK_CONFIG, ORGANIZATION_MANAGEMENT, MARKETPLACE_CONFIG) ->
+        $scope.dockEnabled = DOCK_CONFIG.enabled
         $scope.isOrganizationManagementEnabled = ORGANIZATION_MANAGEMENT.enabled
         $scope.isMarketplaceEnabled = MARKETPLACE_CONFIG.enabled
 
         $scope.$watch(MnoeOrganizations.getSelectedId, (newValue) ->
-          # Impac! is displayed only to admin and super admin
-          MnoeCurrentUser.get().then(
+          ImpacConfigSvc.getOrganizations().then(
             (response) ->
-              selectedOrg = _.find(response.organizations, {id: parseInt(newValue)})
-              $scope.isAdmin = MnoeOrganizations.role.atLeastAdmin(selectedOrg.current_user_role)
+              selectedOrg = _.find(response.organizations, { id: parseInt(newValue) })
+              $scope.impacAvailable = selectedOrg.acl.related.impac.show
           ) if newValue?
         )
 

--- a/src/app/components/dashboard-menu/dashboard-menu.controller.coffee
+++ b/src/app/components/dashboard-menu/dashboard-menu.controller.coffee
@@ -9,7 +9,7 @@ angular.module 'mnoEnterpriseAngular'
       templateUrl: 'app/components/dashboard-menu/dashboard-menu.html',
 
       controller: ($scope, MnoeOrganizations, ImpacConfigSvc, DOCK_CONFIG, ORGANIZATION_MANAGEMENT, MARKETPLACE_CONFIG) ->
-        $scope.dockEnabled = DOCK_CONFIG.enabled
+        $scope.isDockEnabled = DOCK_CONFIG.enabled
         $scope.isOrganizationManagementEnabled = ORGANIZATION_MANAGEMENT.enabled
         $scope.isMarketplaceEnabled = MARKETPLACE_CONFIG.enabled
 
@@ -17,7 +17,7 @@ angular.module 'mnoEnterpriseAngular'
           ImpacConfigSvc.getOrganizations().then(
             (response) ->
               selectedOrg = _.find(response.organizations, { id: parseInt(newValue) })
-              $scope.impacAvailable = selectedOrg.acl.related.impac.show
+              $scope.isImpacAvailable = selectedOrg.acl.related.impac.show
           ) if newValue?
         )
 

--- a/src/app/components/dashboard-menu/dashboard-menu.html
+++ b/src/app/components/dashboard-menu/dashboard-menu.html
@@ -17,19 +17,17 @@
       <!-- ------------------------- -->
       <!-- My account section        -->
       <!-- ------------------------- -->
-      <li>
-        <a ng-if="!isAdmin" ui-sref="home.apps" ui-sref-active="active">{{ 'mno_enterprise.templates.dashboard.menu.dashboard' | translate }}</a>
-      </li>
-      <li ng-if="!isDockEnabled">
-        <a ng-if="isAdmin" ui-sref="home.apps" ui-sref-active="active">{{ 'mno_enterprise.templates.dashboard.menu.dashboard' | translate }}</a>
+
+      <li ng-if="!impacAvailable || !dockEnabled">
+        <a ui-sref="home.apps" ui-sref-active="active">{{ 'mno_enterprise.templates.dashboard.menu.dashboard' | translate }}</a>
       </li>
 
-      <li ng-if="!isDockEnabled">
-        <a ng-if="isAdmin" ui-sref="home.impac" ui-sref-active="active">{{ 'mno_enterprise.templates.dashboard.menu.impac' | translate }}</a>
+      <li ng-if="impacAvailable && dockEnabled">
+        <a ui-sref="home.impac" ui-sref-active="active">{{ 'mno_enterprise.templates.dashboard.menu.dashboard' | translate }}</a>
       </li>
 
-      <li ng-if="isDockEnabled">
-        <a ng-if="isAdmin" ui-sref="home.impac" ui-sref-active="active">{{ 'mno_enterprise.templates.dashboard.menu.dashboard' | translate }}</a>
+      <li ng-if="impacAvailable && !dockEnabled">
+        <a ui-sref="home.impac" ui-sref-active="active">{{ 'mno_enterprise.templates.dashboard.menu.impac' | translate }}</a>
       </li>
 
       <li>
@@ -61,17 +59,17 @@
       <div class='brand-logo'></div>
     </a>
 
-    <a ng-if="(!isDockEnabled && isAdmin) || !isAdmin" ui-sref="home.apps" class="dashboard-button top-buffer-1" ui-sref-active="active">
+    <a ng-if="!impacAvailable || !dockEnabled" ui-sref="home.apps" class="dashboard-button top-buffer-1" ui-sref-active="active">
       <div class='content'>{{ 'mno_enterprise.templates.dashboard.menu.dashboard' | translate }}</div>
       <i class="dhb-icon-dashboard"></i>
     </a>
 
-    <a ng-if="isDockEnabled && isAdmin" ui-sref="home.impac" class="dashboard-button top-buffer-1" ui-sref-active="active">
+    <a ng-if="impacAvailable && dockEnabled" ui-sref="home.impac" class="dashboard-button top-buffer-1" ui-sref-active="active">
       <div class='content'>{{ 'mno_enterprise.templates.dashboard.menu.dashboard' | translate }}</div>
       <i class="dhb-icon-impac"></i>
     </a>
 
-    <a ng-if="!isDockEnabled && isAdmin" ui-sref="home.impac" class="dashboard-button top-buffer-1" ui-sref-active="active">
+    <a ng-if="impacAvailable && !dockEnabled" ui-sref="home.impac" class="dashboard-button top-buffer-1" ui-sref-active="active">
       <div class='content'>{{ 'mno_enterprise.templates.dashboard.menu.impac' | translate }}</div>
       <i class="dhb-icon-impac"></i>
     </a>

--- a/src/app/components/dashboard-menu/dashboard-menu.html
+++ b/src/app/components/dashboard-menu/dashboard-menu.html
@@ -18,15 +18,15 @@
       <!-- My account section        -->
       <!-- ------------------------- -->
 
-      <li ng-if="!impacAvailable || !dockEnabled">
+      <li ng-if="!isImpacAvailable || !isDockEnabled">
         <a ui-sref="home.apps" ui-sref-active="active">{{ 'mno_enterprise.templates.dashboard.menu.dashboard' | translate }}</a>
       </li>
 
-      <li ng-if="impacAvailable && dockEnabled">
+      <li ng-if="isImpacAvailable && isDockEnabled">
         <a ui-sref="home.impac" ui-sref-active="active">{{ 'mno_enterprise.templates.dashboard.menu.dashboard' | translate }}</a>
       </li>
 
-      <li ng-if="impacAvailable && !dockEnabled">
+      <li ng-if="isImpacAvailable && !isDockEnabled">
         <a ui-sref="home.impac" ui-sref-active="active">{{ 'mno_enterprise.templates.dashboard.menu.impac' | translate }}</a>
       </li>
 
@@ -59,17 +59,17 @@
       <div class='brand-logo'></div>
     </a>
 
-    <a ng-if="!impacAvailable || !dockEnabled" ui-sref="home.apps" class="dashboard-button top-buffer-1" ui-sref-active="active">
+    <a ng-if="!isImpacAvailable || !isDockEnabled" ui-sref="home.apps" class="dashboard-button top-buffer-1" ui-sref-active="active">
       <div class='content'>{{ 'mno_enterprise.templates.dashboard.menu.dashboard' | translate }}</div>
       <i class="dhb-icon-dashboard"></i>
     </a>
 
-    <a ng-if="impacAvailable && dockEnabled" ui-sref="home.impac" class="dashboard-button top-buffer-1" ui-sref-active="active">
+    <a ng-if="isImpacAvailable && isDockEnabled" ui-sref="home.impac" class="dashboard-button top-buffer-1" ui-sref-active="active">
       <div class='content'>{{ 'mno_enterprise.templates.dashboard.menu.dashboard' | translate }}</div>
       <i class="dhb-icon-impac"></i>
     </a>
 
-    <a ng-if="impacAvailable && !dockEnabled" ui-sref="home.impac" class="dashboard-button top-buffer-1" ui-sref-active="active">
+    <a ng-if="isImpacAvailable && !isDockEnabled" ui-sref="home.impac" class="dashboard-button top-buffer-1" ui-sref-active="active">
       <div class='content'>{{ 'mno_enterprise.templates.dashboard.menu.impac' | translate }}</div>
       <i class="dhb-icon-impac"></i>
     </a>

--- a/src/app/components/impac-config/impac-config.svc.js.coffee
+++ b/src/app/components/impac-config/impac-config.svc.js.coffee
@@ -1,6 +1,14 @@
 angular.module 'mnoEnterpriseAngular'
   .service('ImpacConfigSvc' , ($log, $q, MnoeCurrentUser, MnoeOrganizations) ->
 
+    _self = @
+
+    @config =
+      customizeAcl: (orgs) -> orgs
+
+    @configure = (customizeAclFunction) ->
+      angular.merge(_self.config, { customizeAcl: customizeAclFunction })
+
     @getUserData = ->
       MnoeCurrentUser.get()
 
@@ -13,7 +21,7 @@ angular.module 'mnoEnterpriseAngular'
             $log.error(err = {msg: "Unable to retrieve user organizations"})
             return $q.reject(err)
 
-          return userOrgs
+          return _self.config.customizeAcl(userOrgs)
       )
 
       currentOrgIdPromise = MnoeOrganizations.get(MnoeOrganizations.selectedId).then(

--- a/src/app/components/impac-config/impac-config.svc.js.coffee
+++ b/src/app/components/impac-config/impac-config.svc.js.coffee
@@ -4,10 +4,10 @@ angular.module 'mnoEnterpriseAngular'
     _self = @
 
     @config =
-      customizeAcl: (orgs) -> orgs
+      overrideOrgs: (orgs) -> orgs
 
-    @configure = (customizeAclFunction) ->
-      angular.merge(_self.config, { customizeAcl: customizeAclFunction })
+    @configure = (overrideOrgsFunction) ->
+      angular.merge(_self.config, { overrideOrgs: overrideOrgsFunction })
 
     @getUserData = ->
       MnoeCurrentUser.get()
@@ -21,7 +21,7 @@ angular.module 'mnoEnterpriseAngular'
             $log.error(err = {msg: "Unable to retrieve user organizations"})
             return $q.reject(err)
 
-          return _self.config.customizeAcl(userOrgs)
+          return _self.config.overrideOrgs(userOrgs)
       )
 
       currentOrgIdPromise = MnoeOrganizations.get(MnoeOrganizations.selectedId).then(
@@ -37,7 +37,7 @@ angular.module 'mnoEnterpriseAngular'
 
       $q.all([userOrgsPromise, currentOrgIdPromise]).then(
         (responses) ->
-          return {organizations: responses[0], currentOrgId: responses[1]}
+          return { organizations: responses[0], currentOrgId: responses[1] }
       )
 
     return @

--- a/src/app/impac.config.coffee
+++ b/src/app/impac.config.coffee
@@ -57,7 +57,6 @@ angular.module 'mnoEnterpriseAngular'
 #======================================================================================
 .run((ImpacLinking, ImpacConfigSvc, IMPAC_CONFIG) ->
   # Example: override ACL for each organization
-  # 
   # overrideAcl = (orgs) ->
   #   _.map(orgs, (org) ->
   #     angular.merge(org, {

--- a/src/app/impac.config.coffee
+++ b/src/app/impac.config.coffee
@@ -56,6 +56,21 @@ angular.module 'mnoEnterpriseAngular'
 # IMPAC-LINKING: Configuring linking
 #======================================================================================
 .run((ImpacLinking, ImpacConfigSvc, IMPAC_CONFIG) ->
+  # Example: override ACL for each organization
+  # 
+  # overrideAcl = (orgs) ->
+  #   _.map(orgs, (org) ->
+  #     angular.merge(org, {
+  #       acl:
+  #         related:
+  #           impac: { show: true }
+  #           dashboards: { update: true }
+  #           widgets: { update: true }
+  #           kpis: { show: true }
+  #     })
+  #   )
+  # ImpacConfigSvc.configure(overrideAcl)
+  
   data =
     user: ImpacConfigSvc.getUserData
     organizations: ImpacConfigSvc.getOrganizations

--- a/src/app/views/apps/dashboard-apps-list.controller.coffee
+++ b/src/app/views/apps/dashboard-apps-list.controller.coffee
@@ -1,6 +1,6 @@
 angular.module 'mnoEnterpriseAngular'
   .controller('DashboardAppsListCtrl',
-    ($scope, $interval, $q, $state, $stateParams, $window, $uibModal, MnoConfirm, MnoeOrganizations, MnoeAppInstances, ImpacConfigSvc, MARKETPLACE_CONFIG) ->
+    ($scope, $interval, $q, $state, $stateParams, $window, $uibModal, MnoConfirm, MnoeOrganizations, MnoeAppInstances, ImpacConfigSvc, MARKETPLACE_CONFIG, DOCK_CONFIG) ->
 
       #====================================
       # Pre-Initialization
@@ -108,8 +108,8 @@ angular.module 'mnoEnterpriseAngular'
         ImpacConfigSvc.getOrganizations().then(
           (resp) ->
             selectedOrg = _.find(resp.organizations, { id: parseInt(val) })
-            if selectedOrg.acl.related.impac.show
-              # Redirects the user to Impac! if authorised
+            if selectedOrg.acl.related.impac.show && DOCK_CONFIG.enabled
+              # Redirects the user to Impac! if authorised (and dock is enabled)
               $state.go('home.impac')
             else
               # Loads the apps otherwise

--- a/src/app/views/apps/dashboard-apps-list.controller.coffee
+++ b/src/app/views/apps/dashboard-apps-list.controller.coffee
@@ -1,6 +1,6 @@
 angular.module 'mnoEnterpriseAngular'
   .controller('DashboardAppsListCtrl',
-    ($scope, $interval, $q, $stateParams, $window, $uibModal, MnoConfirm, MnoeOrganizations, MnoeAppInstances, MARKETPLACE_CONFIG) ->
+    ($scope, $interval, $q, $state, $stateParams, $window, $uibModal, MnoConfirm, MnoeOrganizations, MnoeAppInstances, ImpacConfigSvc, MARKETPLACE_CONFIG) ->
 
       #====================================
       # Pre-Initialization
@@ -104,11 +104,19 @@ angular.module 'mnoEnterpriseAngular'
       # Post-Initialization
       #====================================
       $scope.$watch MnoeOrganizations.getSelectedId, (val) ->
-        if val?
-          $scope.isLoading = true
-          MnoeAppInstances.getAppInstances().then(
-            ->
-              $scope.isLoading = false
-              $scope.apps = MnoeAppInstances.appInstances
-          )
+        $scope.isLoading = true
+        ImpacConfigSvc.getOrganizations().then(
+          (resp) ->
+            selectedOrg = _.find(resp.organizations, { id: parseInt(val) })
+            if selectedOrg.acl.related.impac.show
+              # Redirects the user to Impac! if authorised
+              $state.go('home.impac')
+            else
+              # Loads the apps otherwise
+              MnoeAppInstances.getAppInstances().then(
+                ->
+                  $scope.isLoading = false
+                  $scope.apps = MnoeAppInstances.appInstances
+              )
+        ) if val?
   )

--- a/src/app/views/impac/impac.controller.coffee
+++ b/src/app/views/impac/impac.controller.coffee
@@ -16,10 +16,11 @@ angular.module 'mnoEnterpriseAngular'
         (resp) ->
           selectedOrg = _.find(resp.organizations, { id: parseInt(newValue) })
           if selectedOrg.acl.related.impac.show
-            # Display Impac! and force it to reload if necessary
+            # Displays Impac! and reloads dashboard if user authorised
             vm.isImpacShown = true
             ImpacDashboardsSvc.reload(true) if newValue? && oldValue? && parseInt(newValue) != parseInt(oldValue)
           else
+            # Redirects the user to /apps otherwise
             $state.go('home.apps')
       ) if newValue?
     )

--- a/src/app/views/impac/impac.controller.coffee
+++ b/src/app/views/impac/impac.controller.coffee
@@ -1,5 +1,5 @@
 angular.module 'mnoEnterpriseAngular'
-  .controller 'ImpacController', ($scope, $state, ImpacDashboardsSvc, MnoeCurrentUser, MnoeOrganizations, DOCK_CONFIG) ->
+  .controller 'ImpacController', ($scope, $state, MnoeOrganizations, ImpacConfigSvc, ImpacDashboardsSvc, DOCK_CONFIG) ->
     'ngInject'
 
     vm = this
@@ -10,17 +10,17 @@ angular.module 'mnoEnterpriseAngular'
     # Post-Initialization
     #====================================
     $scope.$watch(MnoeOrganizations.getSelectedId, (newValue, oldValue) ->
-      MnoeCurrentUser.get().then(
-        (response) ->
-          selectedOrg = _.find(response.organizations, {id: parseInt(newValue)})
-          # Needs to be at least admin to display impac! or user is redirected to apps dashboard
-          if MnoeOrganizations.role.atLeastAdmin(selectedOrg.current_user_role)
-            # Display impac! and force it to reload if necessary
-            vm.isImpacShown = true
-            ImpacDashboardsSvc.reload(true) if newValue? && oldValue? && parseInt(newValue) != parseInt(oldValue)
-          else
-            $state.go('home.apps')
-      ) if newValue?
+      if newValue?
+        ImpacConfigSvc.getOrganizations().then(
+          (resp) ->
+            selectedOrg = _.find(resp.organizations, { id: parseInt(newValue) })
+            if selectedOrg.acl.related.impac.show
+              # Display Impac! and force it to reload if necessary
+              vm.isImpacShown = true
+              ImpacDashboardsSvc.reload(true) if newValue? && oldValue? && parseInt(newValue) != parseInt(oldValue)
+            else
+              $state.go('home.apps')
+        )
     )
 
     return

--- a/src/app/views/impac/impac.controller.coffee
+++ b/src/app/views/impac/impac.controller.coffee
@@ -10,17 +10,18 @@ angular.module 'mnoEnterpriseAngular'
     # Post-Initialization
     #====================================
     $scope.$watch(MnoeOrganizations.getSelectedId, (newValue, oldValue) ->
-      if newValue?
-        ImpacConfigSvc.getOrganizations().then(
-          (resp) ->
-            selectedOrg = _.find(resp.organizations, { id: parseInt(newValue) })
-            if selectedOrg.acl.related.impac.show
-              # Display Impac! and force it to reload if necessary
-              vm.isImpacShown = true
-              ImpacDashboardsSvc.reload(true) if newValue? && oldValue? && parseInt(newValue) != parseInt(oldValue)
-            else
-              $state.go('home.apps')
-        )
+      # Fetches the organizations using ImpacConfigSvc (and not MnoeOrganizations)
+      # => Allows to make sure the ACL has already been overriden if necessary (see impac.config.coffee)
+      ImpacConfigSvc.getOrganizations().then(
+        (resp) ->
+          selectedOrg = _.find(resp.organizations, { id: parseInt(newValue) })
+          if selectedOrg.acl.related.impac.show
+            # Display Impac! and force it to reload if necessary
+            vm.isImpacShown = true
+            ImpacDashboardsSvc.reload(true) if newValue? && oldValue? && parseInt(newValue) != parseInt(oldValue)
+          else
+            $state.go('home.apps')
+      ) if newValue?
     )
 
     return

--- a/src/app/views/layout.controller.coffee
+++ b/src/app/views/layout.controller.coffee
@@ -1,19 +1,9 @@
 angular.module 'mnoEnterpriseAngular'
-  .controller 'LayoutController', ($scope, $stateParams, $state, $q, MnoeCurrentUser, MnoeOrganizations) ->
+  .controller 'LayoutController', ($scope, $state) ->
     'ngInject'
 
-    # Impac! is displayed only to admin and super admin
-    $scope.$watch(MnoeOrganizations.getSelectedId, (newValue) ->
-      MnoeCurrentUser.get().then(
-        (response) ->
-          # We only check the role for those states
-          if $state.is('home.impac') || $state.is('home.apps')
-            selectedOrg = _.find(response.organizations, {id: parseInt(newValue)})
-            if MnoeOrganizations.role.atLeastAdmin(selectedOrg.current_user_role)
-              $state.go('home.impac')
-            else
-              $state.go('home.apps')
-      ) if newValue?
-    )
+    # After the layout is loaded, redirects to Impac! controller
+    # => If the user doesn't have access to Impac!, it will redirect him to /apps
+    $state.go('home.impac')
 
     return


### PR DESCRIPTION
- [x] add dependency to MnoHub: https://github.com/maestrano/maestrano-hub/pull/818 and Mnoe: https://github.com/maestrano/mno-enterprise/pull/588

- Rework conditional display of Impac! and menu buttons based on ACL for user / selected organization
- Add `ImpacConfigSvc.configure` = ability to pass a function that customises the list of organizations before passing them to Impac!

**Note**: The ACL for a tenant should be modified via ActiveAdmin (tenant metadata) instead of using the `ImpacConfigSvc.configure` helper. The later is kept in the code as an improvement if some overrides are needed on the organizations passed to Impac!