### PR TITLE
[MNOE-561] Update company name on refresh

### DIFF
--- a/src/app/components/dashboard-company-selectbox/dashboard-company-selectbox.coffee
+++ b/src/app/components/dashboard-company-selectbox/dashboard-company-selectbox.coffee
@@ -27,7 +27,7 @@ DashboardCompanySelectboxCtrl = ($scope, $state, $stateParams, $uibModal, MnoeCu
     selectBox.close()
 
   selectOrganization = ->
-    selectBox.organization = _.find(MnoeCurrentUser.user.organizations, { id: MnoeOrganizations.selectedId })
+    selectBox.organization = MnoeOrganizations.getSelected()?.organization || _.find(MnoeCurrentUser.user.organizations, { id: MnoeOrganizations.selectedId })
 
   # Toggle the select box
   selectBox.toggle = ->


### PR DESCRIPTION
- Company was fetched from MnoeCurrentUser, which relied on the cache from mno-enterprise. Therefore, the company name was not updated on refresh.

- MnoeOrganizations.selected is set right after MnoeOrganizations.selectedId is set.
Since the watch that triggers selectOrganization() is on MnoeOrganizations.selectedId, MnoeOrganizations.selected can be nil at this point, so we keep what we had as a fallback