### PR TITLE
[MNOE-626] Refactor modals to prevent clearing of app instances svc

### DIFF
--- a/src/app/views/apps/modals/app-connect-modal-myob.coffee
+++ b/src/app/views/apps/modals/app-connect-modal-myob.coffee
@@ -2,7 +2,6 @@ angular.module 'mnoEnterpriseAngular'
 .controller('DashboardAppConnectMyobModalCtrl', ($scope, $window, $httpParamSerializer, $uibModalInstance, MnoeAppInstances, app) ->
 
   $scope.app = app
-  $scope.path = MnoeAppInstances.oAuthConnectPath(app)
   $scope.form = {
     perform: true
     version: "essentials"
@@ -10,7 +9,7 @@ angular.module 'mnoEnterpriseAngular'
   $scope.versions = [{name: "Account Right Live", value: "account_right"}, {name: "Essentials", value: "essentials"}]
 
   $scope.connect = (form) ->
-    $window.location.href = $scope.path + $httpParamSerializer(form)
+    $window.location.href = MnoeAppInstances.oAuthConnectPath(app) + $httpParamSerializer(form)
 
   $scope.close = ->
     $uibModalInstance.close()

--- a/src/app/views/apps/modals/app-connect-modal-xero.coffee
+++ b/src/app/views/apps/modals/app-connect-modal-xero.coffee
@@ -2,7 +2,6 @@ angular.module 'mnoEnterpriseAngular'
 .controller('DashboardAppConnectXeroModalCtrl', ($scope, $window, $httpParamSerializer, $uibModalInstance, MnoeAppInstances, app) ->
 
   $scope.app = app
-  $scope.path = MnoeAppInstances.oAuthConnectPath(app)
   $scope.form = {
     perform: true
     xero_country: "AU"
@@ -11,7 +10,7 @@ angular.module 'mnoEnterpriseAngular'
 
   $scope.connect = (form) ->
     form['extra_params[]'] = "payroll" if $scope.payroll
-    $window.location.href = $scope.path + $httpParamSerializer(form)
+    $window.location.href = MnoeAppInstances.oAuthConnectPath(app) + $httpParamSerializer(form)
 
   $scope.close = ->
     $uibModalInstance.close()


### PR DESCRIPTION
@alexnoox The call to `MnoeAppInstances.oAuthConnectPath(app)` in the modals was happening before it was needed and was causing all of the app instances to be cleared from the `MnoeAppInstances` service. I refactored the modals to prevent the apps from disappearing from the dock pre-maturely. 