### PR TITLE
[MNOE-1018] Fix refresh bug

### DIFF
--- a/src/app/components/mnoe-api/provisioning.svc.coffee
+++ b/src/app/components/mnoe-api/provisioning.svc.coffee
@@ -21,13 +21,16 @@ angular.module 'mnoEnterpriseAngular'
       subscription
 
     # Return the subscription
+    # if editing return the subscription in cache
     # if productNid: return the default subscription
     # if subscriptionId: return the fetched subscription
-    # else: return the subscription in cache (edition mode)
-    @initSubscription = ({productNid = null, subscriptionId = null}) ->
+    # else: return an empty object (this condition should never be met, but is a failsafe)
+    @initSubscription = ({productNid = null, subscriptionId = null, editing = false}) ->
       deferred = $q.defer()
 
-      if productNid?
+      if editing
+        deferred.resolve(subscription)
+      else if productNid?
         # Create a new subscription to a product
         angular.copy(defaultSubscription, subscription)
         deferred.resolve(subscription)
@@ -39,7 +42,8 @@ angular.module 'mnoEnterpriseAngular'
             deferred.resolve(subscription)
         )
       else
-        deferred.resolve(subscription)
+        deferred.resolve({})
+
       return deferred.promise
 
     @createSubscription = (s) ->

--- a/src/app/index.route.coffee
+++ b/src/app/index.route.coffee
@@ -186,7 +186,7 @@ angular.module 'mnoEnterpriseAngular'
         .state 'home.provisioning.order',
           data:
             pageTitle:'Purchase - Order'
-          url: '/order/?nid&id'
+          url: '/order/?nid&id&editing'
           views: '@home.provisioning':
             templateUrl: 'app/views/provisioning/order.html'
             controller: 'ProvisioningOrderCtrl'
@@ -194,7 +194,7 @@ angular.module 'mnoEnterpriseAngular'
         .state 'home.provisioning.additional_details',
           data:
             pageTitle:'Purchase - Additional details'
-          url: '/details/'
+          url: '/details/?nid&id'
           views: '@home.provisioning':
             templateUrl: 'app/views/provisioning/details.html'
             controller: 'ProvisioningDetailsCtrl'
@@ -202,7 +202,7 @@ angular.module 'mnoEnterpriseAngular'
         .state 'home.provisioning.confirm',
           data:
             pageTitle:'Purchase - Confirm'
-          url: '/confirm/'
+          url: '/confirm/?nid&id'
           views: '@home.provisioning':
             templateUrl: 'app/views/provisioning/confirm.html'
             controller: 'ProvisioningConfirmCtrl'

--- a/src/app/views/provisioning/confirm.controller.coffee
+++ b/src/app/views/provisioning/confirm.controller.coffee
@@ -1,10 +1,17 @@
 angular.module 'mnoEnterpriseAngular'
-  .controller('ProvisioningConfirmCtrl', ($scope, $state, MnoeOrganizations, MnoeProvisioning, MnoeAppInstances, MnoeConfig) ->
+  .controller('ProvisioningConfirmCtrl', ($scope, $state, $stateParams, MnoeOrganizations, MnoeProvisioning, MnoeAppInstances, MnoeConfig) ->
 
     vm = this
 
     vm.isLoading = false
     vm.subscription = MnoeProvisioning.getSubscription()
+
+    if _.isEmpty(vm.subscription)
+      # Redirect the user to the first provisioning screen
+      $state.go('home.provisioning.order', {id: $stateParams.id, nid: $stateParams.nid}, {reload: true})
+
+    vm.editOrder = () ->
+      $state.go('home.provisioning.order', {id: $stateParams.id, nid: $stateParams.nid, editing: true})
 
     vm.validate = () ->
       vm.isLoading = true

--- a/src/app/views/provisioning/confirm.html
+++ b/src/app/views/provisioning/confirm.html
@@ -70,7 +70,7 @@
     </div>
 
     <span class="pull-right top-buffer-1">
-      <button class="btn btn-primary" ui-sref="home.provisioning.order()" translate>mno_enterprise.templates.dashboard.provisioning.confirm.edit_order</button>
+      <button class="btn btn-primary" ng-click="vm.editOrder()" translate>mno_enterprise.templates.dashboard.provisioning.confirm.edit_order</button>
       <button class="btn btn-warning" ng-click="vm.validate()" ng-disabled="vm.isLoading">
         <span ng-show="vm.isLoading"><i class="fa fa-spinner fa-pulse fa-fw"></i></span>
         <span translate>mno_enterprise.templates.dashboard.provisioning.confirm.validate</span>

--- a/src/app/views/provisioning/details.controller.coffee
+++ b/src/app/views/provisioning/details.controller.coffee
@@ -1,11 +1,17 @@
 angular.module 'mnoEnterpriseAngular'
-  .controller('ProvisioningDetailsCtrl', ($state, MnoeMarketplace, MnoeProvisioning, schemaForm) ->
+  .controller('ProvisioningDetailsCtrl', ($state, MnoeMarketplace, MnoeProvisioning, schemaForm, $stateParams) ->
 
     vm = this
 
     vm.form = [ "*" ]
 
     vm.subscription = MnoeProvisioning.getSubscription()
+
+    # Happen when the user reload the browser during the provisioning
+    if _.isEmpty(vm.subscription)
+      # Redirect the user to the first provisioning screen
+      $state.go('home.provisioning.order', {id: $stateParams.id, nid: $stateParams.nid}, {reload: true})
+
     vm.isEditMode = !_.isEmpty(vm.subscription.custom_data)
 
     # The schema is contained in field vm.product.custom_schema
@@ -24,7 +30,7 @@ angular.module 'mnoEnterpriseAngular'
     vm.submit = (form) ->
       return if form.$invalid
       MnoeProvisioning.setSubscription(vm.subscription)
-      $state.go('home.provisioning.confirm')
+      $state.go('home.provisioning.confirm', {id: $stateParams.id, nid: $stateParams.nid})
 
     return
   )

--- a/src/app/views/provisioning/order.controller.coffee
+++ b/src/app/views/provisioning/order.controller.coffee
@@ -7,7 +7,7 @@ angular.module 'mnoEnterpriseAngular'
 
     orgPromise = MnoeOrganizations.get()
     prodsPromise = MnoeMarketplace.getProducts()
-    initPromise = MnoeProvisioning.initSubscription({productNid: $stateParams.nid, subscriptionId: $stateParams.id})
+    initPromise = MnoeProvisioning.initSubscription({productNid: $stateParams.nid, subscriptionId: $stateParams.id, editing: $stateParams.editing})
 
     $q.all({organization: orgPromise, products: prodsPromise, subscription: initPromise}).then(
       (response) ->
@@ -34,9 +34,9 @@ angular.module 'mnoEnterpriseAngular'
     vm.next = (subscription) ->
       MnoeProvisioning.setSubscription(subscription)
       if vm.subscription.product.custom_schema?
-        $state.go('home.provisioning.additional_details')
+        $state.go('home.provisioning.additional_details', {id: $stateParams.id, nid: $stateParams.nid})
       else
-        $state.go('home.provisioning.confirm')
+        $state.go('home.provisioning.confirm', {id: $stateParams.id, nid: $stateParams.nid})
 
     # Return true if the plan has a dollar value
     vm.pricedPlan = (plan) ->


### PR DESCRIPTION
1) Add nid, and orgId to browser params, so that when you refresh you can redirect to the correct page.

2) Add an editing mode to the browser params to account for the browser params in one (before we would return a cached response if the browser params did not have the nid/orgId, since we need that in the params for refresh, we needed another way to tell whether or not we should return the cached subscription). 