### PR TITLE
[OPAL-305] Update Product pricings when organization is changed

### DIFF
--- a/src/app/components/mno-apps/mno-app.coffee
+++ b/src/app/components/mno-apps/mno-app.coffee
@@ -72,6 +72,9 @@ angular.module 'mnoEnterpriseAngular'
       vm.app = app
       vm.appInstance = appInstance
 
+      # Update Pricing Plans
+      getPricingPlans(vm.app)
+
       # Is the product externally provisioned
       vm.isExternallyProvisioned = (vm.isProvisioningEnabled && product?.externally_provisioned)
 


### PR DESCRIPTION
- ~~When fetching apps/products, we do not get updated pricing details since we are showing cached versions of the apps against that organization.~~

- Allow Product pricings to be updated when organization is changed
