### PR TITLE
Fixed bug where order summary pages crashes becuase of missing editAction param

### DIFF
--- a/src/app/views/provisioning/confirm.controller.coffee
+++ b/src/app/views/provisioning/confirm.controller.coffee
@@ -37,7 +37,7 @@ angular.module 'mnoEnterpriseAngular'
             (response) ->
               $scope.apps = response
           )
-          $state.go('home.provisioning.order_summary', {subscriptionId: $stateParams.subscriptionId})
+          $state.go('home.provisioning.order_summary', {subscriptionId: $stateParams.subscriptionId, editAction: $stateParams.editAction})
       ).finally(-> vm.isLoading = false)
 
     vm.editOrder = () ->


### PR DESCRIPTION
[Layout controller](https://github.com/maestrano/mno-enterprise-angular/blob/2.0/src/app/views/layout.controller.coffee#L8) crashes because the editAction param is not passed when an order is `Validated`