### PR TITLE
[OPAL-513] Locales displayed on "Validate"

### DIFF
--- a/src/app/components/mno-app-install-btn/mno-app-install-btn.coffee
+++ b/src/app/components/mno-app-install-btn/mno-app-install-btn.coffee
@@ -206,7 +206,7 @@ angular.module 'mnoEnterpriseAngular'
             # Are there any available plans
             availablePlans = ProvisioningHelper.plansForCurrency(plans, currency)
 
-            vm.orderPossible = !_.isEmpty(availablePlans) || (plans.default&[0] && currencySelection) || ProvisioningHelper.skipPriceSelection(product)
+            vm.orderPossible = !_.isEmpty(availablePlans) || (plans.default?[0] && currencySelection) || ProvisioningHelper.skipPriceSelection(product)
 
             vm.buttonText = vm.updateButtonText()
             vm.buttonDisabledTooltip = vm.updateButtonDisabledTooltip()

--- a/src/app/views/provisioning/summary.controller.coffee
+++ b/src/app/views/provisioning/summary.controller.coffee
@@ -8,20 +8,22 @@ angular.module 'mnoEnterpriseAngular'
     vm.selectedCurrency = MnoeProvisioning.getSelectedCurrency()
     vm.subType = if $stateParams.cart == 'true' then 'cart' else 'active'
     vm.subscription = MnoeProvisioning.getCachedSubscription()
-    vm.quoteBased = vm.subscription.product_pricing.quote_based
-    vm.quote = MnoeProvisioning.getCachedQuote() if vm.quoteBased
+
+    initSummary = () ->
+      vm.singleBilling = vm.subscription.product.single_billing_enabled
+      vm.billedLocally = vm.subscription.product.billed_locally
+      vm.quoteBased = vm.subscription.product_pricing?.quote_based
+      vm.quote = MnoeProvisioning.getCachedQuote() if vm.quoteBased
 
     if !_.isEmpty(vm.subscription)
+      initSummary()
       vm.isLoading = false
     else
       MnoeProvisioning.initSubscription({subscriptionId: $stateParams.subscriptionId})
         .then((response) ->
           vm.subscription = response
-          vm.singleBilling = vm.subscription.product.single_billing_enabled
-          vm.billedLocally = vm.subscription.product.billed_locally
-          vm.quoteBased = vm.subscription.product_pricing.quote_based
-          )
-        .finally(() -> vm.isLoading = false)
+          initSummary()
+        ).finally(() -> vm.isLoading = false)
 
     vm.orderTypeText = 'mno_enterprise.templates.dashboard.provisioning.subscriptions.' + $stateParams.editAction.toLowerCase()
 


### PR DESCRIPTION
Add guarding to summary controller to prevent error thrown when product
is set to skip price selection.