### PR TITLE
[OPALSUP-265] Fix public marketplace view

### DIFF
--- a/src/app/components/mno-apps/mno-app-listing.coffee
+++ b/src/app/components/mno-apps/mno-app-listing.coffee
@@ -40,7 +40,7 @@ angular.module 'mnoEnterpriseAngular'
         vm.searchTerm = ''
         vm.currentSelectedCategory = if vm.publicPage then vm.selectedPublicCategory.label else vm.selectedCategory
         if (vm.currentSelectedCategory?.length > 0)
-          vm.filteredApps = (app for app in vm.apps when vm.currentSelectedCategory in app.categories)
+          vm.filteredApps = _.filter(vm.apps, (app) -> _.includes(app.categories, vm.currentSelectedCategory))
         else
           vm.filteredApps = vm.apps
 
@@ -84,11 +84,12 @@ angular.module 'mnoEnterpriseAngular'
             response = response.plain()
 
             vm.categories = response.categories
-            vm.publicCategories = _.map(response.categories, (c) -> {label: c, active: ''})
             vm.apps = response.apps
-            vm.filteredApps = vm.apps
             if vm.publicPage
               vm.apps = _.filter(vm.apps, (app) -> _.includes(MnoeConfig.publicApplications(), app.nid))
+              categoriesWithProduct = _.uniq(_.flatten(_.map(vm.apps, (app) -> app.categories)))
+              vm.publicCategories = _.map(categoriesWithProduct, (c) -> {label: c, active: ''})
+            vm.filteredApps = vm.apps
       ).finally(-> vm.isLoading = false)
 
       $scope.$watch MnoeOrganizations.getSelectedId, (val) ->

--- a/src/app/components/mno-local-products/mno-local-product-listing.coffee
+++ b/src/app/components/mno-local-products/mno-local-product-listing.coffee
@@ -33,7 +33,7 @@ angular.module 'mnoEnterpriseAngular'
       # Post-Initialization
       #====================================
       $scope.$watch MnoeOrganizations.getSelectedId, (val) ->
-        vm.initialize() if val?
+        vm.initialize()
 
       return
     })

--- a/src/app/views/public/landing/landing.controller.coffee
+++ b/src/app/views/public/landing/landing.controller.coffee
@@ -4,12 +4,11 @@ angular.module 'mnoEnterpriseAngular'
 
       vm = @
       vm.isLoading = true
-      vm.localProductLoading = true
       vm.highlightedApps = []
       vm.localProducts = []
 
       vm.carouselImageStyle = (app) ->
-        # Products does not have a picture
+        # Select appropriate image for carousel - logo or picture
         picture = if app.pictures then app.pictures[0] else app.logo
         {
           "background-image": "url(#{picture})"
@@ -17,13 +16,11 @@ angular.module 'mnoEnterpriseAngular'
 
       MnoeMarketplace.getApps().then(
         (response) ->
-          vm.products = _.filter(response.apps, (app) -> _.includes(MnoeConfig.publicApplications(), app.nid))
           vm.highlightedApps = _.filter(response.apps, (app) -> _.includes(MnoeConfig.publicHighlightedApplications(), app.nid))
           if MnoeConfig.areLocalProductsEnabled
             vm.localProducts = _.filter(response.products, (product) -> product.local && _.includes(MnoeConfig.publicLocalProducts(), product.nid))
             localHighlightedApp = _.filter(response.products, (product) -> _.includes(MnoeConfig.publicHighlightedLocalProducts(), product.nid))
             vm.highlightedApps = vm.highlightedApps.concat(localHighlightedApp) if localHighlightedApp
-          vm.categories = response.categories
       ).finally(-> vm.isLoading = false)
 
       vm.highlightHref = (app) ->


### PR DESCRIPTION
The public marketplace view on the landing page now correctly
shows local products flagged as public, removes categories
where no public products are configured and on initial view
does no longer shows all products initially.

This change also fixes the category selection in the marketplace
which was not working because not all products have categories.