### PR TITLE
[MNOE-1277] Product display allow undefined org

### DIFF
--- a/src/app/components/mno-apps/mno-app.coffee
+++ b/src/app/components/mno-apps/mno-app.coffee
@@ -55,7 +55,7 @@ angular.module 'mnoEnterpriseAngular'
         vm.app ||= _.findWhere(apps, { id:  appId })
 
         # Init currency
-        vm.currency = MnoeOrganizations.selected.organization.billing_currency || MnoeConfig.marketplaceCurrency()
+        vm.currency = MnoeOrganizations.selected?.organization?.billing_currency || MnoeConfig.marketplaceCurrency()
 
         # Init Pricing Plans
         getPricingPlans()


### PR DESCRIPTION
The detailed product display component is designed to show
product information within the landing page where a user
is not logged and there is no selected organisation.

Fix the logic to support this use case by not relying on
a selected organisation.