### PR TITLE
[OPALSUP-281] Add billing currency flag

### DIFF
--- a/src/app/components/mnoe-config/mnoe-config.svc.coffee
+++ b/src/app/components/mnoe-config/mnoe-config.svc.coffee
@@ -37,6 +37,13 @@ angular.module 'mnoEnterpriseAngular'
         $log.debug("DASHBOARD_CONFIG.organization_management.billing.enabled missing")
         true
 
+    @isBillingCurrencySelectionEnabled = () ->
+      if DASHBOARD_CONFIG.organization_management?.billing?.billing_currency_selection?
+        DASHBOARD_CONFIG.organization_management.billing.billing_currency_selection
+      else
+        $log.debug("DASHBOARD_CONFIG.organization_management.billing.billing_currency_selection missing")
+        true
+
     @isCurrencySelectionEnabled = () ->
       if DASHBOARD_CONFIG.marketplace?.pricing?.currency_selection?
         DASHBOARD_CONFIG.marketplace.pricing.currency_selection

--- a/src/app/views/company/settings/organization-settings.directive.coffee
+++ b/src/app/views/company/settings/organization-settings.directive.coffee
@@ -13,6 +13,12 @@ DashboardOrganizationSettingsCtrl = ($scope, $window, MnoeOrganizations, Utiliti
   #====================================
   # Scope Management
   #====================================
+  # Feature flags
+  $scope.currencies = MnoeConfig.availableBillingCurrencies()
+  $scope.currencySelection = MnoeConfig.isBillingCurrencySelectionEnabled()
+  $scope.mainAddressRequired = MnoeOrganizations.mainAddressRequired()
+  $scope.currencySelectionDisabledTooltip = if $scope.currencySelection then '' else 'mno_enterprise.templates.dashboard.organization.settings.billing_currency_disabled_tooltip'
+
   # Initialize the data used by the directive
   $scope.initialize = (organization) ->
     angular.copy(organization, $scope.model)
@@ -52,18 +58,6 @@ DashboardOrganizationSettingsCtrl = ($scope, $window, MnoeOrganizations, Utiliti
   $scope.isSaveEnabled = ->
     f = $scope.forms
     $scope.isChanged() && f.settings.$valid
-
-  $scope.isCurrencyChangeShown = ->
-    if MnoeOrganizations.role.isSuperAdmin()
-      $scope.getAvailableBillingCurrencies()
-      true
-    else
-      false
-
-  $scope.getAvailableBillingCurrencies = ->
-    $scope.currencies = MnoeConfig.availableBillingCurrencies()
-
-  $scope.mainAddressRequired = MnoeOrganizations.mainAddressRequired()
 
   #====================================
   # Post-Initialization

--- a/src/app/views/company/settings/organization-settings.html
+++ b/src/app/views/company/settings/organization-settings.html
@@ -11,7 +11,7 @@
 </div>
 
 
-<div class="row">
+<div class="row organization-settings">
   <form name="forms.settings" role="form" novalidate class="form-horizontal">
     <div class="form-group">
       <label class="col-sm-3 control-label">{{ 'mno_enterprise.templates.dashboard.organization.settings.company_name' | translate }}*</label>
@@ -20,10 +20,10 @@
       </div>
     </div>
 
-    <div class="form-group" ng-if="isCurrencyChangeShown()">
+    <div class="form-group">
       <label class="col-sm-3 control-label">{{ 'mno_enterprise.templates.dashboard.organization.settings.billing_currency' | translate }}*</label>
-      <div class="col-sm-6">
-        <select ng-model="model.billing_currency" class="form-control">
+      <div class="col-sm-6" uib-tooltip="{{ currencySelectionDisabledTooltip | translate }}" ng-class="{'disabled': !currencySelection}">
+        <select ng-model="model.billing_currency" ng-disabled="!currencySelection" class="form-control">
           <option ng-repeat="currency in currencies" value="{{::currency}}">{{::currency}}</option>
         </select>
       </div>

--- a/src/app/views/company/settings/organization-settings.less
+++ b/src/app/views/company/settings/organization-settings.less
@@ -8,3 +8,13 @@
     margin-top: -12px;
   }
 }
+
+.organization-settings {
+  div.disabled {
+    cursor: not-allowed
+  }
+
+  [disabled] {
+    pointer-events: none;
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -684,6 +684,7 @@
   "mno_enterprise.templates.dashboard.organization.members.removal_modal.remove": "Remove",
   "mno_enterprise.templates.dashboard.organization.settings.company_name": "Company name",
   "mno_enterprise.templates.dashboard.organization.settings.billing_currency": "Billing currency",
+  "mno_enterprise.templates.dashboard.organization.settings.billing_currency_disabled_tooltip": "Please contact support to change your billing currency",
   "mno_enterprise.templates.dashboard.organization.settings.main_address": "Main address",
   "mno_enterprise.templates.dashboard.organization.settings.connec_data_sharing": "Connec!™ Data Sharing",
   "mno_enterprise.templates.dashboard.organization.settings.enable": "On",


### PR DESCRIPTION
Add a new flag to control the ability to select an organization billing currency.
Removed the condition around 'Super Admin' as the directive is only shown for 'Super Admin'

New flag:
![image](https://user-images.githubusercontent.com/19894/44969220-8d439200-af8f-11e8-9316-072f7a08be26.png)

Tooltip when disabled:
![image](https://user-images.githubusercontent.com/19894/44969228-946aa000-af8f-11e8-97e7-a83adc626ca9.png)
