### PR TITLE
Update dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-angular": "^1.3.0",
     "fancy-log": "^1.3.2",
     "glob": "^7.1.2",
-    "gulp": "gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "gulp-angular-filesort": "^1.2.1",
     "gulp-angular-templatecache": "^2.2.1",
     "gulp-coffee": "^2.3.3",


### PR DESCRIPTION
Update gulp dev dependency in package.json as gulp 4.0 is now available
directly from npm (git reference is no longer valid)